### PR TITLE
Bump acorn to 8.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "ember-addon"
   ],
   "dependencies": {
-    "acorn": "^4.0.3",
+    "acorn": "^8.0.1",
     "array-binsearch": "^1.0.0",
     "broccoli-persistent-filter": "^1.2.11",
     "estree-walker": "^0.3.0",


### PR DESCRIPTION
Bumping acorn since v4.0.3 doesn't support async/await. v8.0.1 is the latest version for acorn.