### PR TITLE
Acorn parse options (fix for PR#8)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,6 @@ before_install:
   - npm config set spin false
   - npm install -g bower
   - bower --version
-  - npm install phantomjs-prebuilt
-  - node_modules/phantomjs-prebuilt/bin/phantomjs --version
 
 install:
   - npm install

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -138,6 +138,9 @@ module.exports = function(defaults) {
         'ember-resolver/utils/create':true,
         'ember-resolver/utils/make-dictionary':true,
         'ember-resolver/utils/module-registry':true
+      },
+      parseOptions: {
+        ecmaVersion: 8
       }
     }
   });

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -140,7 +140,7 @@ module.exports = function(defaults) {
         'ember-resolver/utils/module-registry':true
       },
       parseOptions: {
-        ecmaVersion: 8
+        ecmaVersion: 2017
       }
     }
   });

--- a/lib/optimize.js
+++ b/lib/optimize.js
@@ -17,6 +17,8 @@ function Optimize(inputNode, options) {
     annotation: options.annotation
   });
   this.eager = options.eager;
+  // adding option to override acorn.parse options.
+  this.parseOptions = options.parseOptions || {};
 }
 
 Optimize.prototype.extensions = ['js'];
@@ -24,7 +26,7 @@ Optimize.prototype.targetExtension = 'js';
 
 Optimize.prototype.processString = function(content, relativePath) {
   logger.debug('opt   ' + relativePath);
-  var ast = parse(content);
+  var ast = parse(content, this.parseOptions);
   var optimizer = new Optimizer(content, ast, this.eager);
   walk(ast, {
     enter: function (node, parent) {

--- a/testem.js
+++ b/testem.js
@@ -4,10 +4,19 @@ module.exports = {
   "test_page": "tests/index.html?hidepassed",
   "disable_watching": true,
   "launch_in_ci": [
-    "PhantomJS"
+    "Chrome"
   ],
   "launch_in_dev": [
-    "PhantomJS",
     "Chrome"
-  ]
+  ],
+  "browser_args": {
+    "Chrome": [
+      "--headless",
+      "--disable-gpu",
+      "--remote-debugging-port=9222",
+      "--remote-debugging-address=0.0.0.0",
+      "--no-sandbox",
+      "--user-data-dir=/tmp"
+    ]
+  }
 };


### PR DESCRIPTION
Fix for PR #8 
- Added parse options support
- Removed phantomJS as test runner in CI as it is already deprecated and it  was causing test failure.
- Added Chromium as the test runner.